### PR TITLE
KotlinSprint-13-1 — package creation

### DIFF
--- a/src/main/kotlin/lesson_13/lesson_13_task_1.kt
+++ b/src/main/kotlin/lesson_13/lesson_13_task_1.kt
@@ -1,2 +1,13 @@
 package lesson_13
 
+fun main() {
+
+    val member = PhoneBookMember("Ryan Gosling", 89219219219, null)
+
+}
+
+class PhoneBookMember(
+    val name: String,
+    val phoneNumber: Long,
+    val companyName: String?,
+)


### PR DESCRIPTION
> При создании объекта компания может оставаться незаполненной. Вместо пустой строки поле может принимать null.

У меня напрашивалось реализовать это через вторичный конструктор с дополнительным обнуляемым полем с именем компании, но условие `Все свойства класса не должны иметь инициализации по умолчанию.` не подразумевает этого, как я понял. Всё верно? 